### PR TITLE
Change select input to 16px font size

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -59,7 +59,7 @@ const Home = () => {
           <label>Filters</label>
           <Select
             isMulti
-            styles={{ input: { fontSize: '16px' }}}
+            styles={{ input: () => ({ fontSize: '16px', })}}
             instanceId='filter-select'
             options={buildFilters()}
             onChange={setFilters}

--- a/pages/index.js
+++ b/pages/index.js
@@ -59,6 +59,7 @@ const Home = () => {
           <label>Filters</label>
           <Select
             isMulti
+            styles={{ input: { fontSize: '16px' }}}
             instanceId='filter-select'
             options={buildFilters()}
             onChange={setFilters}


### PR DESCRIPTION
Something annoying on iOS: If an input has a font size of less than 16px, it causes the page to be zoomed in on the input